### PR TITLE
Fixes #1: Remove assigned ports from try-list

### DIFF
--- a/tasks/port-pick.js
+++ b/tasks/port-pick.js
@@ -56,6 +56,9 @@ module.exports = function(grunt) {
     async.series([
       function(callback){
         async.eachSeries(pp.tryPorts, pp.checkPort, function(foundPort) {
+          if (foundPort) {
+            while (pp.tryPorts.shift() !== foundPort);
+          }
           callback(foundPort)
         })
       },


### PR DESCRIPTION
When a port is found, originating from the tryPorts-list, then all ports up to (and including) that port will be removed from the tryPorts-list.

I'm not 100% sure this is the best place to do this, but at the very least this might point others in the right direction.
