### PR TITLE
Properly handle ports as strings

### DIFF
--- a/tasks/port-pick.js
+++ b/tasks/port-pick.js
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
       function(callback){
         if(pp.usePorts && pp.usePorts.length > 0) {
           var foundPort = pp.usePorts.shift()
-          pp.first = foundPort + 1
+          pp.first = parseInt(foundPort) + 1
           used.push(foundPort)
           grunt.config.set('port-pick-used', used.join(','))
           callback(foundPort)
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
 
             // If we use a port, increment so that it isn't used again
             if(foundPort !== false) {
-              pp.first = foundPort + 1
+              pp.first = parseInt(foundPort) + 1
               used.push(foundPort)
               grunt.config.set('port-pick-used', used.join(','))
             }


### PR DESCRIPTION
Some ports can be strings when parsing port data from the command line.  This change prevents 1 from being appended to the port string and properly adds it to the port number.

Example:

```
$ grunt portPick --portPickUsePorts=13666
Running "portPick:karma" (portPick) task
>> karma.options.port=13666
>> karma=13666

Running "portPick:livereload" (portPick) task
Fatal error: port should be >= 0 and < 65536: 136661
```