### PR TITLE
Set peerDependencies of grunt to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "portscanner": "^1.0.0"
   },
   "peerDependencies": {
-    "grunt": "*"
+    "grunt": ">=0.4.5"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Fix for users that don't want to use grunt@1.0.0 (or cannot use)

See this section in the releases notes of grunt:
http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies
